### PR TITLE
fix: 手机小屏小“拼音”按钮切换错位

### DIFF
--- a/src/app/[lang]/poem/[id]/page.tsx
+++ b/src/app/[lang]/poem/[id]/page.tsx
@@ -133,13 +133,13 @@ export default async function Page({ params, searchParams }: Props) {
                 {dict.poem.title}
               </Link>
               <ChevronRight className="h-4 w-4 flex-shrink-0" strokeWidth={1} />
-              <span className="line-clamp-1 w-28 overflow-hidden text-foreground md:w-auto">
+              <span className="line-clamp-1 overflow-hidden text-foreground">
                 {poem.title}
               </span>
             </nav>
           </div>
 
-          <div>
+          <div className="min-w-24">
             {showPinYin ? (
               <Button size={"xs"} aria-label={dict.poem.pinyin_hide} asChild>
                 <Link href="?" replace>

--- a/src/app/[lang]/poem/[id]/page.tsx
+++ b/src/app/[lang]/poem/[id]/page.tsx
@@ -139,7 +139,7 @@ export default async function Page({ params, searchParams }: Props) {
             </nav>
           </div>
 
-          <div className="min-w-24">
+          <div className="flex justify-end items-center min-w-24">
             {showPinYin ? (
               <Button size={"xs"} aria-label={dict.poem.pinyin_hide} asChild>
                 <Link href="?" replace>


### PR DESCRIPTION
修复了手机屏幕宽度较小时，诗歌详情页顶部“拼音”按钮跟分割线的布局问题。

问题如下图所示：
![pinyin-button](https://github.com/meetqy/aspoem/assets/49969025/19d06b6c-c8ff-4d6e-ab89-ced5f4cf447c)
